### PR TITLE
Update workflow permissions so it can push to GHCR

### DIFF
--- a/.github/workflows/tutorial-docker-image.yml
+++ b/.github/workflows/tutorial-docker-image.yml
@@ -10,6 +10,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: llnl/raja-suite-tutorial/tutorial
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
 
   build:


### PR DESCRIPTION
Latest workflow run to push image to GHCR failed: https://github.com/LLNL/raja-suite-tutorial/actions/runs/16511454821/job/46694100179

This PR would allow this workflow to write packages.

I think our organizations default permissions were changed, as I had the same problem with some of my workflows this week.